### PR TITLE
docs: update README for formula name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ brew tap dbt-labs/dbt-cli
 To install the the `dbt` command from the tap, run
 
 ```
-brew install dbt
+brew install dbt-cloud-cli
 ```


### PR DESCRIPTION
This patch updates the README to point to the correct formula name.